### PR TITLE
Feature: govulncheck をCIで実行するようにする

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -1,0 +1,26 @@
+name: govulncheck
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.0.0
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+        working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## WHY

[golang/vuln の v1.0.0 がリリースされた](https://github.com/golang/vuln/releases/tag/v1.0.0) ので．

## WHAT

これをCIで実行する